### PR TITLE
refactor ui enhancements

### DIFF
--- a/src/apps/sequencer/engine/NoteTrackEngine.h
+++ b/src/apps/sequencer/engine/NoteTrackEngine.h
@@ -46,6 +46,8 @@ public:
 
     void setMonitorStep(int index);
 
+    Types::PlayMode playMode() const { return _noteTrack.playMode(); }
+
 private:
     void triggerStep(uint32_t tick, uint32_t divisor, bool nextStep);
     void triggerStep(uint32_t tick, uint32_t divisor);

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -11,6 +11,7 @@
 #include "core/utils/StringBuilder.h"
 #include <iostream>
 #include <map>
+#include <unordered_map>
 
 enum class ContextAction {
     Init,
@@ -411,24 +412,18 @@ void CurveSequenceEditPage::encoder(EncoderEvent &event) {
     auto &sequence = _project.selectedCurveSequence();
 
     if (!_stepSelection.any()) {
-        switch (layer()) {
-        case Layer::Shape:
-            setLayer(event.value() > 0 ? Layer::ShapeVariation : Layer::ShapeVariationProbability);
-            break;
-        case Layer::ShapeVariation:
-            setLayer(event.value() > 0 ? Layer::ShapeVariationProbability : Layer::Shape);
-            break;
-        case Layer::ShapeVariationProbability:
-            setLayer(event.value() > 0 ? Layer::Shape : Layer::ShapeVariation);
-            break;
-        case Layer::Gate:
-            setLayer(Layer::GateProbability);
-            break;
-        case Layer::GateProbability:
-            setLayer(Layer::Gate);
-            break;
-        default:
-            break;
+        std::unordered_map<CurveSequence::Layer, std::pair<CurveSequence::Layer, Layer>> layerMap = {
+            { Layer::Shape, { Layer::ShapeVariation, Layer::ShapeVariationProbability } },
+            { Layer::ShapeVariation, { Layer::ShapeVariationProbability, Layer::Shape } },
+            { Layer::ShapeVariationProbability, { Layer::Shape, Layer::ShapeVariation } },
+            { Layer::Min, { Layer::Max, Layer::Max } },
+            { Layer::Max, { Layer::Min, Layer::Min } },
+            { Layer::Gate, { Layer::GateProbability, Layer::GateProbability } },
+            { Layer::GateProbability, { Layer::Gate, Layer::Gate } },
+        };
+        auto it = layerMap.find(layer());
+        if (it != layerMap.end()) {
+            setLayer(event.value() > 0 ? it->second.first : it->second.second);
         }
         return;
     } else {


### PR DESCRIPTION
simplifies the code from switch-case to unordered_map to make it easier to read and more easily expandable.

Additionally: limits visibility of the "repeat" and "repeat mode" layers only to when the track mode is "free"