### PR TITLE
simplify note tie UX

### DIFF
--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -373,7 +373,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
 
     if (key.isFunction()) {
-        if(key.shiftModifier() && key.function() == 2) {
+        if(key.shiftModifier() && key.function() == 2 && _stepSelection.any()) {
             tieNotes();
             event.consume();
             return;

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -326,12 +326,6 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     const auto &key = event.key();
     auto &sequence = _project.selectedNoteSequence();
 
-    if (key.isQuickEdit()) {
-        if (key.is(Key::Step15)) {
-            tieNotes();
-        }
-    }
-
     if (key.isContextMenu()) {
         contextShow();
         event.consume();
@@ -379,6 +373,10 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
 
     if (key.isFunction()) {
+        if(key.shiftModifier() && key.function() == 2) {
+            tieNotes();
+            event.consume();
+        }
         switchLayer(key.function(), key.shiftModifier());
         event.consume();
     }

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -376,6 +376,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
         if(key.shiftModifier() && key.function() == 2) {
             tieNotes();
             event.consume();
+            return;
         }
         switchLayer(key.function(), key.shiftModifier());
         event.consume();


### PR DESCRIPTION
Changes the "note tie" functionality to use fewer keys and more logical in placement.

To tie notes:
hold shift
press multiple steps
while shift is still held, press the "length" function key

I can see how this could work under either the "gate" _or_ the "length" key, but since the `tieNotes()` function modified the note lengths I chose to place it under "length"