### PR TITLE
move page follow UX to page+s16

### DIFF
--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -383,6 +383,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
 
     if (key.isEncoder()) {
+        setSectionTracking(false);
         if (!_showDetail && _stepSelection.any() && allSelectedStepsActive()) {
             setSelectedStepsGate(false);
         } else {

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -339,17 +339,17 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
 
     if (key.isQuickEdit()) {
+        if (key.is(Key::Step15)) {
+            setSectionTracking(not _sectionTracking);
+            event.consume();
+            return;
+        }
         quickEdit(key.quickEdit());
         event.consume();
         return;
     }
 
     if (key.pageModifier()) {
-        // XXX Added here, but should we move it to pageModifier structure?
-        if (key.is(Key::Step5)) {
-            setSectionTracking(not _sectionTracking);
-            event.consume();
-        }
         return;
     }
 
@@ -384,8 +384,6 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
 
     if (key.isEncoder()) {
-        setSectionTracking(false);
-
         if (!_showDetail && _stepSelection.any() && allSelectedStepsActive()) {
             setSelectedStepsGate(false);
         } else {


### PR DESCRIPTION
Moves the page follow functionality from page+S6 to page+s16. I think this placement makes more sense and the "Last" quickEdit type seems to be unused