### PR TITLE
Feature/20 pattern follow

### DIFF
--- a/src/apps/sequencer/engine/NoteTrackEngine.cpp
+++ b/src/apps/sequencer/engine/NoteTrackEngine.cpp
@@ -141,9 +141,9 @@ TrackEngine::TickResult NoteTrackEngine::tick(uint32_t tick) {
                 _sequenceState.advanceAligned(relativeTick / divisor, sequence.runMode(), sequence.firstStep(), sequence.lastStep(), rng);
                 recordStep(tick, divisor);
                 triggerStep(tick, divisor);
-                
+
                 _sequenceState.calculateNextStepAligned(
-                        (relativeTick + divisor) / divisor, 
+                        (relativeTick + divisor) / divisor,
                         sequence.runMode(),
                         sequence.firstStep(),
                         sequence.lastStep(),
@@ -166,11 +166,11 @@ TrackEngine::TickResult NoteTrackEngine::tick(uint32_t tick) {
                 recordStep(tick, divisor);
                 const auto &step = sequence.step(_sequenceState.step());
                 bool isLastStageStep = ((int) (step.stageRepeats()+1) - (int) _currentStageRepeat) <= 0;
-            
+
                 triggerStep(tick+divisor, divisor);
-                               
+
                 if (isLastStageStep) {
-                   _currentStageRepeat = 1; 
+                   _currentStageRepeat = 1;
                 } else {
                     _currentStageRepeat++;
                 }
@@ -332,7 +332,7 @@ void NoteTrackEngine::triggerStep(uint32_t tick, uint32_t divisor, bool forNextS
 
     // TODO do we need to encounter rotate?
     _currentStep = SequenceUtils::rotateStep(_sequenceState.step(), sequence.firstStep(), sequence.lastStep(), rotate);
-    
+
     int stepIndex;
 
     if (forNextStep) {
@@ -397,7 +397,7 @@ void NoteTrackEngine::triggerStep(uint32_t tick, uint32_t divisor, bool forNextS
                     case 6:
                         stepGate = stepGate && (_currentStageRepeat - 1) % 3 == 0;
                         break;
-                
+
                 }
                 break;
     }

--- a/src/apps/sequencer/model/NoteTrack.h
+++ b/src/apps/sequencer/model/NoteTrack.h
@@ -14,7 +14,7 @@ public:
     //----------------------------------------
     // Types
     //----------------------------------------
-    static constexpr size_t NameLength = FileHeader::NameLength; 
+    static constexpr size_t NameLength = FileHeader::NameLength;
 
     typedef std::array<NoteSequence, CONFIG_PATTERN_COUNT + CONFIG_SNAPSHOT_COUNT> NoteSequenceArray;
 
@@ -270,6 +270,42 @@ public:
         str("%+.1f%%", noteProbabilityBias() * 12.5f);
     }
 
+    // patternFollow
+    Types::PatternFollow patternFollow() const { return _patternFollow; }
+    void setPatternFollow(const Types::PatternFollow patternFollow) {
+        _patternFollow = ModelUtils::clampedEnum(patternFollow);
+    }
+
+    void setPatternFollow(bool trackDisplay, bool trackLP) {
+
+        if (trackDisplay && trackLP) {
+            setPatternFollow(Types::PatternFollow::DispAndLP);
+            return;
+        }
+
+        else if (trackDisplay) {
+            setPatternFollow(Types::PatternFollow::Display);
+            return;
+        }
+
+        else if (trackLP) {
+            setPatternFollow(Types::PatternFollow::LaunchPad);
+            return;
+        }
+
+        setPatternFollow(Types::PatternFollow::Off);
+
+        return;
+    }
+
+    void editPatternFollow(int value, bool shift) {
+        setPatternFollow(ModelUtils::adjustedEnum(patternFollow(), value));
+    }
+
+    void printPatternFollow(StringBuilder &str) const {
+        str(Types::patternFollowName(patternFollow()));
+    }
+
     // sequences
 
     const NoteSequenceArray &sequences() const { return _sequences; }
@@ -319,6 +355,7 @@ private:
     Routable<int8_t> _retriggerProbabilityBias;
     Routable<int8_t> _lengthBias;
     Routable<int8_t> _noteProbabilityBias;
+    Types::PatternFollow _patternFollow;
 
     NoteSequenceArray _sequences;
 

--- a/src/apps/sequencer/model/Types.h
+++ b/src/apps/sequencer/model/Types.h
@@ -138,6 +138,27 @@ public:
         return nullptr;
     }
 
+    // Pattern Follow
+    enum class PatternFollow : uint8_t {
+        Off,
+        Display,
+        LaunchPad,
+        DispAndLP,
+        Last
+    };
+
+    static const char *patternFollowName(PatternFollow patternFollow) {
+        switch (patternFollow) {
+        case PatternFollow::Off:      return "Off";
+        case PatternFollow::Display:      return "Display";
+        case PatternFollow::LaunchPad:      return "LaunchPad";
+        case PatternFollow::DispAndLP:      return "Display+LP";
+        case PatternFollow::Last:         break;
+        }
+        return nullptr;
+    }
+
+
     // Condition
 
     enum class Condition : uint8_t {

--- a/src/apps/sequencer/ui/model/NoteTrackListModel.h
+++ b/src/apps/sequencer/ui/model/NoteTrackListModel.h
@@ -72,6 +72,7 @@ private:
         RetriggerProbabilityBias,
         LengthBias,
         NoteProbabilityBias,
+        PatternFollow,
         Last
     };
 
@@ -90,6 +91,7 @@ private:
         case RetriggerProbabilityBias: return "Retrig P. Bias";
         case LengthBias: return "Length Bias";
         case NoteProbabilityBias: return "Note P. Bias";
+        case PatternFollow: return "Pattern Follow";
         case Last:      break;
         }
         return nullptr;
@@ -140,6 +142,9 @@ private:
         case NoteProbabilityBias:
             _track->printNoteProbabilityBias(str);
             break;
+        case PatternFollow:
+            _track->printPatternFollow(str);
+            break;
         case Last:
             break;
         }
@@ -185,6 +190,9 @@ private:
             break;
         case NoteProbabilityBias:
             _track->editNoteProbabilityBias(value, shift);
+            break;
+        case PatternFollow:
+            _track->editPatternFollow(value, shift);
             break;
         case Last:
             break;

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -73,9 +73,13 @@ void NoteSequenceEditPage::exit() {
 void NoteSequenceEditPage::draw(Canvas &canvas) {
     WindowPainter::clear(canvas);
 
+    const auto &note_track = _project.selectedTrack().noteTrack();
+
     /* Prepare flags shown before mode name (top right header) */
     const char *mode_flags = NULL;
-    if (_sectionTracking) {
+
+    const auto pattern_follow = note_track.patternFollow();
+    if (pattern_follow == Types::PatternFollow::Display || pattern_follow == Types::PatternFollow::DispAndLP) {
         const char *st_flag = "F";
         mode_flags = st_flag;
     }
@@ -86,6 +90,7 @@ void NoteSequenceEditPage::draw(Canvas &canvas) {
     WindowPainter::drawFooter(canvas, functionNames, pageKeyState(), activeFunctionKey());
 
     const auto &trackEngine = _engine.selectedTrackEngine().as<NoteTrackEngine>();
+
     const auto &sequence = _project.selectedNoteSequence();
     const auto &scale = sequence.selectedScale(_project.scale());
     int currentStep = trackEngine.isActiveSequence(sequence) ? trackEngine.currentStep() : -1;
@@ -96,9 +101,8 @@ void NoteSequenceEditPage::draw(Canvas &canvas) {
 
     const int loopY = 16;
 
-
     // Track Pattern Section on the UI
-    if (_sectionTracking && _engine.state().running()) {
+    if (isSectionTracking() && _engine.state().running()) {
         bool section_change = bool((currentStep) % StepCount == 0); // StepCount is relative to screen
         int section_no = int((currentStep) / StepCount);
         if (section_change && section_no != _section) {
@@ -347,7 +351,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     if (key.pageModifier()) {
         // XXX Added here, but should we move it to pageModifier structure?
         if (key.is(Key::Step5)) {
-            setSectionTracking(not _sectionTracking);
+            toggleSectionTracking();
             event.consume();
         }
         return;
@@ -932,8 +936,37 @@ void NoteSequenceEditPage::duplicateSequence() {
 /*
  * Makes the UI track the current step section
  */
-void NoteSequenceEditPage::setSectionTracking(bool track) {
-    _sectionTracking = track;
+void NoteSequenceEditPage::setSectionTracking(bool trackDisplay) {
+    auto &note_track = _project.selectedTrack().noteTrack();
+    const auto pattern_follow = note_track.patternFollow();
+
+    const bool lp_tracking =
+        (pattern_follow == Types::PatternFollow::LaunchPad ||
+         pattern_follow == Types::PatternFollow::DispAndLP);
+
+    note_track.setPatternFollow(trackDisplay, lp_tracking);
+}
+
+bool NoteSequenceEditPage::isSectionTracking() {
+    auto &note_track = _project.selectedTrack().noteTrack();
+    const auto pattern_follow = note_track.patternFollow();
+
+    return (pattern_follow == Types::PatternFollow::Display ||
+            pattern_follow == Types::PatternFollow::DispAndLP);
+}
+
+
+void NoteSequenceEditPage::toggleSectionTracking() {
+    auto &note_track = _project.selectedTrack().noteTrack();
+    const auto pattern_follow = note_track.patternFollow();
+
+    const bool disp_tracking = isSectionTracking();
+
+    const bool lp_tracking =
+        (pattern_follow == Types::PatternFollow::LaunchPad ||
+         pattern_follow == Types::PatternFollow::DispAndLP);
+
+    note_track.setPatternFollow(not disp_tracking, lp_tracking);
 }
 
 void NoteSequenceEditPage::tieNotes() {

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
@@ -56,12 +56,13 @@ private:
     void setSelectedStepsGate(bool gate);
 
     void setSectionTracking(bool track);
+    bool isSectionTracking();
+    void toggleSectionTracking();
 
     NoteSequence::Layer layer() const { return _project.selectedNoteSequenceLayer(); };
     void setLayer(NoteSequence::Layer layer) { _project.setSelectedNoteSequenceLayer(layer); }
 
     int _section = 0;
-    bool _sectionTracking = false;
     bool _showDetail;
     uint32_t _showDetailTicks;
 


### PR DESCRIPTION
This PR enhances #20 by adding a Track menu entry to select the Pattern Follow mode between : Off, Display, Launchpad or Display + LP.

Atm, only Display is implemented (I don't have my LP on hand).
It is also only available for the Note track type, not Curve as it was stated in the issue.

Also, I'm not happy with the naïve enum handling of cases but I can't figure out how to use them as flags for 2 reasons: operator overloading won't work and the performer menu expects values of +1 between each menu entry (which makes it impossible to use power of 2 for flags).

