### PR TITLE
[Pattern Follow] Implement Display and LaunchPad tracking on display

### DIFF
--- a/src/apps/sequencer/model/BaseTrackPatternFollow.h
+++ b/src/apps/sequencer/model/BaseTrackPatternFollow.h
@@ -11,7 +11,7 @@
 
 class BaseTrackPatternFollow {
 public:
-    
+
     // patternFollow
     Types::PatternFollow patternFollow() const { return _patternFollow; }
     void setPatternFollow(const Types::PatternFollow patternFollow) {
@@ -38,6 +38,36 @@ public:
         setPatternFollow(Types::PatternFollow::Off);
 
         return;
+    }
+
+    void setPatternFollowDisplay(bool trackDisplay) {
+        const auto pattern_follow = patternFollow();
+
+        const bool lp_tracking =
+            (pattern_follow == Types::PatternFollow::LaunchPad ||
+             pattern_follow == Types::PatternFollow::DispAndLP);
+
+        setPatternFollow(trackDisplay, lp_tracking);
+    }
+
+    bool isPatternFollowDisplayOn() {
+        const auto pattern_follow = patternFollow();
+
+        return (pattern_follow == Types::PatternFollow::Display ||
+                pattern_follow == Types::PatternFollow::DispAndLP);
+    }
+
+
+    void togglePatternFollowDisplay() {
+        const auto pattern_follow = patternFollow();
+
+        const bool disp_tracking = isPatternFollowDisplayOn();
+
+        const bool lp_tracking =
+            (pattern_follow == Types::PatternFollow::LaunchPad ||
+             pattern_follow == Types::PatternFollow::DispAndLP);
+
+        setPatternFollow(not disp_tracking, lp_tracking);
     }
 
     void editPatternFollow(int value, bool shift) {

--- a/src/apps/sequencer/model/Types.h
+++ b/src/apps/sequencer/model/Types.h
@@ -158,6 +158,18 @@ public:
         return nullptr;
     }
 
+    static const char* patternFollowShortRepresentation(PatternFollow patternFollow) {
+        switch (patternFollow) {
+        case PatternFollow::Off:      return nullptr;
+        case Types::PatternFollow::Display:      return "F";
+        case Types::PatternFollow::LaunchPad:    return "F:LP";
+        case Types::PatternFollow::DispAndLP:    return "F:D+LP";
+        case PatternFollow::Last:           break;
+        }
+        return nullptr;
+    }
+
+
 
     // Condition
 
@@ -330,7 +342,7 @@ public:
         str(names[note]);
     }
 
-    
+
 
     static void printMidiNote(StringBuilder &str, int midiNote) {
         printNote(str, midiNote % 12);

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
@@ -49,10 +49,6 @@ private:
     void generateSequence();
 
     void quickEdit(int index);
-    
-    void setSectionTracking(bool track);
-    bool isSectionTracking();
-    void toggleSectionTracking();
 
     CurveSequence::Layer layer() const { return _project.selectedCurveSequenceLayer(); }
     void setLayer(CurveSequence::Layer layer) { _project.setSelectedCurveSequenceLayer(layer); }

--- a/src/platform/sim/sim/TargetTrace.cpp
+++ b/src/platform/sim/sim/TargetTrace.cpp
@@ -5,7 +5,6 @@
 #include "tinyformat.h"
 
 #include <iomanip>
-#include <memory>
 
 namespace sim {
 

--- a/src/platform/sim/sim/TargetTrace.cpp
+++ b/src/platform/sim/sim/TargetTrace.cpp
@@ -5,7 +5,7 @@
 #include "tinyformat.h"
 
 #include <iomanip>
-
+#include <memory>
 
 namespace sim {
 


### PR DESCRIPTION
Hi @mebitek ,

Here's the PR for both Curve and Note pattern follow, on both display and launchpad.

LP is not detected atm and mode cycling is as smart as it can be but can be enhanced as discussed once we sens if the LP is here or not.

I've removed code duplication by moving code to superclass.

