### PR TITLE
Feature 48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - smart cycling on patter follow modes (check if launchpad is connected)
 - Show launchpad settings only when a launchpad is connected
 - Apply random for selected steps only
+- double click page to enter context menu for 2 seconds
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Show launchpad settings only when a launchpad is connected
 - Apply random for selected steps only
 - double click page to enter context menu for 2 seconds
-- Prevent very short output clock pulses at higher BPMs
+- Prevent very short output clock pulses at higher BPMs3
+- Undo function (alt+s7)
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Show launchpad settings only when a launchpad is connected
 - Apply random for selected steps only
 - double click page to enter context menu for 2 seconds
-- Prevent very short output clock pulses at higher BPMs3
+- Prevent very short output clock pulses at higher BPMs
 - Undo function (alt+s7)
 - Curve mode backward run modes play reverse playback
 - Bypass the Voltage Table in specific steps of the sequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Show launchpad settings only when a launchpad is connected
 - Apply random for selected steps only
 - double click page to enter context menu for 2 seconds
+- Prevent very short output clock pulses at higher BPMs
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - INIT by step selected
 - smart cycling on patter follow modes (check if launchpad is connected)
 - Show launchpad settings only when a launchpad is connected
+- Apply random for selected steps only
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # v0.1.4.48 ()
 - Moving steps in a sequence
 - INIT by step selected
+- smart cycling on patter follow modes (check if launchpad is connected)
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - double click page to enter context menu for 2 seconds
 - Prevent very short output clock pulses at higher BPMs3
 - Undo function (alt+s7)
+- Curve mode backward run modes play reverse playback
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Prevent very short output clock pulses at higher BPMs3
 - Undo function (alt+s7)
 - Curve mode backward run modes play reverse playback
+- Bypass the Voltage Table in specific steps of the sequence
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# v0.1.4.48 ()
+# v0.1.4.48 (30 January 2024)
 - Moving steps in a sequence
 - INIT by step selected
 - smart cycling on patter follow modes (check if launchpad is connected)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v0.1.4.48 ()
+- Moving steps in a sequence
+- INIT by step selected
+
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements
 - random generator: random seed just on init method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Moving steps in a sequence
 - INIT by step selected
 - smart cycling on patter follow modes (check if launchpad is connected)
+- Show launchpad settings only when a launchpad is connected
 
 # v0.1.4.47 (24 January 2024)
 - launchpad circuit mode improvements

--- a/src/apps/sequencer/Config.h
+++ b/src/apps/sequencer/Config.h
@@ -7,7 +7,7 @@
 #define CONFIG_VERSION_NAME             "PER|FORMER SEQUENCER"
 #define CONFIG_VERSION_MAJOR            0
 #define CONFIG_VERSION_MINOR            1
-#define CONFIG_VERSION_REVISION         47
+#define CONFIG_VERSION_REVISION         48
 
 // Task priorities
 #define CONFIG_DRIVER_TASK_PRIORITY     5

--- a/src/apps/sequencer/engine/Clock.cpp
+++ b/src/apps/sequencer/engine/Clock.cpp
@@ -419,7 +419,7 @@ void Clock::outputTick(uint32_t tick) {
 
     if (tick == _output.nextTick) {
         uint32_t divisor = _output.divisor;
-        uint32_t clockDuration = std::max(uint32_t(1), uint32_t(_masterBpm * _ppqn * _output.pulse / (60 * 1000)));
+        uint32_t clockDuration = std::max(uint32_t(10), uint32_t(_masterBpm * _ppqn * _output.pulse / (60 * 1000)));
 
         _output.nextTickOn = applySwing(_output.nextTick);
         _output.nextTickOff = std::min(_output.nextTickOn + clockDuration, applySwing(_output.nextTick + divisor) - 1);

--- a/src/apps/sequencer/engine/CurveTrackEngine.cpp
+++ b/src/apps/sequencer/engine/CurveTrackEngine.cpp
@@ -14,8 +14,11 @@
 
 static Random rng;
 
-static float evalStepShape(const CurveSequence::Step &step, bool variation, bool invert, float fraction) {
+static float evalStepShape(const CurveSequence::Step &step, bool variation, bool invert, float fraction, int direction) {
     auto function = Curve::function(Curve::Type(variation ? step.shapeVariation() : step.shape()));
+    if (direction == -1) {
+        function = Curve::function(Curve::Type(variation ? step.shapeVariation() : Curve::revAt(step.shape())));
+    }
     float value = function(fraction);
     if (invert) {
         value = 1.f - value;
@@ -218,7 +221,7 @@ void CurveTrackEngine::updateOutput(uint32_t relativeTick, uint32_t divisor) {
         const auto &evalSequence = fillNextPattern ? *_fillSequence : *_sequence;
         const auto &step = evalSequence.step(_currentStep);
 
-        float value = evalStepShape(step, _shapeVariation || fillVariation, fillInvert || _sequenceState.direction() == -1, _currentStepFraction);
+        float value = evalStepShape(step, _shapeVariation || fillVariation, fillInvert, _currentStepFraction, _sequenceState.direction());
         value = range.denormalize(value);
         _cvOutputTarget = value;
     }

--- a/src/apps/sequencer/engine/CurveTrackEngine.cpp
+++ b/src/apps/sequencer/engine/CurveTrackEngine.cpp
@@ -218,7 +218,7 @@ void CurveTrackEngine::updateOutput(uint32_t relativeTick, uint32_t divisor) {
         const auto &evalSequence = fillNextPattern ? *_fillSequence : *_sequence;
         const auto &step = evalSequence.step(_currentStep);
 
-        float value = evalStepShape(step, _shapeVariation || fillVariation, fillInvert, _currentStepFraction);
+        float value = evalStepShape(step, _shapeVariation || fillVariation, fillInvert || _sequenceState.direction() == -1, _currentStepFraction);
         value = range.denormalize(value);
         _cvOutputTarget = value;
     }

--- a/src/apps/sequencer/engine/CurveTrackEngine.cpp
+++ b/src/apps/sequencer/engine/CurveTrackEngine.cpp
@@ -14,50 +14,10 @@
 
 static Random rng;
 
-static const std::map<int, Curve::Type> REV_SHAPE_MAP = {
-        {0, Curve::Low},
-        {1, Curve::High},
-        {2, Curve::RampDown},
-        {3, Curve::RampUp},
-        {4, Curve::rampDownHalf},
-        {5, Curve::rampUpHalf},
-        {6, Curve::doubleRampDownHalf},
-        {7, Curve::doubleRampUpHalf},
-        {8, Curve::ExpDown},
-        {9, Curve::ExpUp},
-        {10, Curve::expDownHalf},
-        {11, Curve:: expUpHalf},
-        {12, Curve::doubleExpDownHalf},
-        {13, Curve::doubleExpUpHalf},
-        {14, Curve::LogDown},
-        {15, Curve::LogUp},
-        {16, Curve::logDownHalf},
-        {17, Curve::logUpHalf},
-        {18, Curve::doubleLogDownHalf},
-        {19, Curve::doubleLogUpHalf},
-        {20, Curve::SmoothDown},
-        {21, Curve::SmoothUp},
-        {22, Curve::smoothDownHalf},
-        {23, Curve::smoothUpHalf},
-        {24, Curve::doubleSmoothDownHalf},
-        {25, Curve::doubleSmoothUpHalf},
-        {26, Curve::Triangle},
-        {27, Curve::RevTriangle},
-        {28, Curve::Bell},
-        {29, Curve::RevBell},
-        {30, Curve::StepDown},
-        {31, Curve::StepUp},
-        {32, Curve::ExpUp2x},
-        {33, Curve::ExpDown2x},
-        {34, Curve::ExpUp3x},
-        {35, Curve::ExpUp4x},
-        {36, Curve::ExpDown4x}
-    };
-
 static float evalStepShape(const CurveSequence::Step &step, bool variation, bool invert, float fraction, int direction) {
     auto function = Curve::function(Curve::Type(variation ? step.shapeVariation() : step.shape()));
     if (direction == -1) {
-        function = Curve::function(Curve::Type(variation ? step.shapeVariation() : REV_SHAPE_MAP.at(step.shape())));
+        function = Curve::function(Curve::Type(variation ? step.shapeVariation() : Curve::revAt(step.shape())));
     }
     float value = function(fraction);
     if (invert) {

--- a/src/apps/sequencer/engine/CurveTrackEngine.cpp
+++ b/src/apps/sequencer/engine/CurveTrackEngine.cpp
@@ -14,10 +14,50 @@
 
 static Random rng;
 
+static const std::map<int, Curve::Type> REV_SHAPE_MAP = {
+        {0, Curve::Low},
+        {1, Curve::High},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::Triangle},
+        {27, Curve::RevTriangle},
+        {28, Curve::Bell},
+        {29, Curve::RevBell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
+
 static float evalStepShape(const CurveSequence::Step &step, bool variation, bool invert, float fraction, int direction) {
     auto function = Curve::function(Curve::Type(variation ? step.shapeVariation() : step.shape()));
     if (direction == -1) {
-        function = Curve::function(Curve::Type(variation ? step.shapeVariation() : Curve::revAt(step.shape())));
+        function = Curve::function(Curve::Type(variation ? step.shapeVariation() : REV_SHAPE_MAP.at(step.shape())));
     }
     float value = function(fraction);
     if (invert) {

--- a/src/apps/sequencer/engine/CurveTrackEngine.h
+++ b/src/apps/sequencer/engine/CurveTrackEngine.h
@@ -45,6 +45,10 @@ public:
     void setMonitorStep(int index) { _monitorStepIndex = (index >= 0 && index < CONFIG_STEP_COUNT) ? index : -1; }
     void setMonitorStepLevel(MonitorLevel level) { _monitorStepLevel = level; }
 
+    SequenceState sequenceState() {
+        return _sequenceState;
+    }
+
 private:
     void triggerStep(uint32_t tick, uint32_t divisor);
     void updateOutput(uint32_t relativeTick, uint32_t divisor);

--- a/src/apps/sequencer/engine/Engine.cpp
+++ b/src/apps/sequencer/engine/Engine.cpp
@@ -5,6 +5,7 @@
 
 #include "core/Debug.h"
 #include "core/midi/MidiMessage.h"
+#include "ui/ControllerManager.h"
 
 #include "os/os.h"
 
@@ -663,15 +664,28 @@ void Engine::updateOverrides() {
 }
 
 void Engine::usbMidiConnect(uint16_t vendorId, uint16_t productId) {
+    
     if (_usbMidiConnectHandler) {
         _usbMidiConnectHandler(vendorId, productId);
+
+        auto lp = ControllerManager::findController(vendorId, productId);
+
+        if (lp) {
+            _deviceConnected = true;
+        }
     }
 }
 
 void Engine::usbMidiDisconnect() {
     if (_usbMidiDisconnectHandler) {
         _usbMidiDisconnectHandler();
+        _deviceConnected = false;
     }
+}
+
+bool Engine::isLaunchpadConnected() {
+    return _deviceConnected;
+    
 }
 
 void Engine::receiveMidi() {

--- a/src/apps/sequencer/engine/Engine.h
+++ b/src/apps/sequencer/engine/Engine.h
@@ -160,6 +160,9 @@ public:
 
     Stats stats() const;
 
+     bool isLaunchpadConnected();
+
+
 private:
     // Clock::Listener
     virtual void onClockOutput(const Clock::OutputState &state) override;
@@ -173,7 +176,7 @@ private:
 
     void usbMidiConnect(uint16_t vendorId, uint16_t productId);
     void usbMidiDisconnect();
-
+   
     void receiveMidi();
     void receiveMidi(MidiPort port, uint8_t cable, const MidiMessage &message);
     void monitorMidi(const MidiMessage &message);
@@ -259,4 +262,6 @@ private:
     std::array<float, CvOutput::Channels> _cvOutputOverrideValues;
 
     MessageHandler _messageHandler;
+
+    bool _deviceConnected = false;
 };

--- a/src/apps/sequencer/engine/SequenceState.cpp
+++ b/src/apps/sequencer/engine/SequenceState.cpp
@@ -120,6 +120,7 @@ void SequenceState::calculateNextStepFree(Types::RunMode runMode, int firstStep,
             } else {
                 ++_nextStep;
             }
+            _direction = 1;
             break;
         case Types::RunMode::Backward:
             if (_step <= firstStep) {
@@ -128,6 +129,7 @@ void SequenceState::calculateNextStepFree(Types::RunMode runMode, int firstStep,
             } else {
                 --_nextStep;
             }
+            _direction = -1;
             break;
         case Types::RunMode::Pendulum:
         case Types::RunMode::PingPong:
@@ -178,20 +180,34 @@ void SequenceState::calculateNextStepAligned(int absoluteStep, Types::RunMode ru
     case Types::RunMode::Forward:
          _nextStep = firstStep + absoluteStep % stepCount;
         _iteration = absoluteStep / stepCount;
+        _direction = 1;
         break;
     case Types::RunMode::Backward:
         _nextStep = lastStep - absoluteStep % stepCount;
         _iteration = absoluteStep / stepCount;
+        _direction = -1; 
         break;
     case Types::RunMode::Pendulum:
         _iteration = absoluteStep / (2 * stepCount);
         absoluteStep %= (2 * stepCount);
         _nextStep = (absoluteStep < stepCount) ? (firstStep + absoluteStep) : (lastStep - (absoluteStep - stepCount));
+        if (_direction > 0 && _step>= lastStep) {
+                _direction = -1;
+            } else if (_direction < 0 && _step <= firstStep) {
+                _direction = 1;
+                ++_nextIteration;
+            }
         break;
     case Types::RunMode::PingPong:
         _iteration = absoluteStep / (2 * stepCount - 2);
         absoluteStep %= (2 * stepCount - 2);
         _nextStep = (absoluteStep < stepCount) ? (firstStep + absoluteStep) : (lastStep - (absoluteStep - stepCount) - 1);
+        if (_direction > 0 && _step>= lastStep) {
+                _direction = -1;
+            } else if (_direction < 0 && _step <= firstStep) {
+                _direction = 1;
+                ++_nextIteration;
+            }
         break;
     case Types::RunMode::Random:
         _nextStep = firstStep + rng.nextRange(stepCount);
@@ -211,8 +227,10 @@ void SequenceState::advanceRandomWalk(int firstStep, int lastStep, Random &rng) 
         int dir = rng.nextRange(2);
         if (dir == 0) {
             _nextStep = _step == firstStep ? lastStep : _step - 1;
+            _direction = -1;
         } else {
             _nextStep = _step == lastStep ? firstStep : _step + 1;
+            _direction = 1;
         }
     }
 }

--- a/src/apps/sequencer/engine/SequenceState.h
+++ b/src/apps/sequencer/engine/SequenceState.h
@@ -11,7 +11,7 @@ public:
     int step() const { return _step; }
     int prevStep() const { return _prevStep; }
     int nextStep() const { return _nextStep; }
-    int direction() const { return _direction; }
+    int direction() { return _direction; }
     uint32_t iteration() const { return _iteration; }
 
 

--- a/src/apps/sequencer/engine/generators/Generator.cpp
+++ b/src/apps/sequencer/engine/generators/Generator.cpp
@@ -13,7 +13,7 @@ static void initLayer(SequenceBuilder &builder) {
     builder.clearLayer();
 }
 
-Generator *Generator::execute(Generator::Mode mode, SequenceBuilder &builder) {
+Generator *Generator::execute(Generator::Mode mode, SequenceBuilder &builder, std::bitset<CONFIG_STEP_COUNT> &selected) {
     switch (mode) {
     case Mode::InitLayer:
         initLayer(builder);
@@ -21,7 +21,7 @@ Generator *Generator::execute(Generator::Mode mode, SequenceBuilder &builder) {
     case Mode::Euclidean:
         return generatorContainer.create<EuclideanGenerator>(builder, euclideanParams);
     case Mode::Random:
-        return generatorContainer.create<RandomGenerator>(builder, randomParams);
+        return generatorContainer.create<RandomGenerator>(builder, randomParams, selected);
     case Mode::Last:
         break;
     }

--- a/src/apps/sequencer/engine/generators/Generator.h
+++ b/src/apps/sequencer/engine/generators/Generator.h
@@ -51,7 +51,7 @@ public:
 
     virtual void update() = 0;
 
-    static Generator *execute(Generator::Mode mode, SequenceBuilder &builder);
+    static Generator *execute(Generator::Mode mode, SequenceBuilder &builder, std::bitset<CONFIG_STEP_COUNT> &selected);
 
 protected:
     SequenceBuilder &_builder;

--- a/src/apps/sequencer/engine/generators/RandomGenerator.cpp
+++ b/src/apps/sequencer/engine/generators/RandomGenerator.cpp
@@ -1,12 +1,14 @@
 #include "RandomGenerator.h"
 
 #include "core/utils/Random.h"
+#include <bitset>
+#include <cstddef>
 #include <ctime>
 
-
-RandomGenerator::RandomGenerator(SequenceBuilder &builder, Params &params) :
+RandomGenerator::RandomGenerator(SequenceBuilder &builder, Params &params, std::bitset<CONFIG_STEP_COUNT> &selected) :
     Generator(builder),
-    _params(params)
+    _params(params),
+    _selected(selected)
 {
     update();
 }
@@ -59,12 +61,18 @@ void RandomGenerator::update() {
     int size = _pattern.size();
 
     for (int i = 0; i < size; ++i) {
-        _pattern[i] = rng.nextRange(255);
+        if (_selected[i]) {
+            _pattern[i] = rng.nextRange(255);
+        } else {
+            _pattern[i] = 0;
+        }
     }
 
     for (int iteration = 0; iteration < _params.smooth; ++iteration) {
         for (int i = 0; i < size; ++i) {
-            _pattern[i] = (4 * _pattern[i] + _pattern[(i - 1 + size) % size] + _pattern[(i + 1) % size] + 3) / 6;
+            if (_selected[i]) {
+                _pattern[i] = (4 * _pattern[i] + _pattern[(i - 1 + size) % size] + _pattern[(i + 1) % size] + 3) / 6;
+            }
         }
     }
 
@@ -72,13 +80,17 @@ void RandomGenerator::update() {
     int scale = _params.scale;
 
     for (int i = 0; i < size; ++i) {
-        int value = _pattern[i];
-        // value = ((value - 127) * scale) / 10 + 127 + bias;
-        value = ((value + bias - 127) * scale) / 10 + 127;
-        _pattern[i] = clamp(value, 0, 255);
+        if (_selected[i]) {
+            int value = _pattern[i];
+            // value = ((value - 127) * scale) / 10 + 127 + bias;
+            value = ((value + bias - 127) * scale) / 10 + 127;
+            _pattern[i] = clamp(value, 0, 255);
+        } 
     }
 
     for (size_t i = 0; i < _pattern.size(); ++i) {
-        _builder.setValue(i, _pattern[i] * (1.f / 255.f));
+        if (_selected[i]) {
+            _builder.setValue(i, _pattern[i] * (1.f / 255.f));
+        }
     }
 }

--- a/src/apps/sequencer/engine/generators/RandomGenerator.h
+++ b/src/apps/sequencer/engine/generators/RandomGenerator.h
@@ -5,6 +5,7 @@
 #include "Generator.h"
 
 #include "core/math/Math.h"
+#include <bitset>
 
 class RandomGenerator : public Generator {
 public:
@@ -23,7 +24,7 @@ public:
         uint8_t scale = 5;
     };
 
-    RandomGenerator(SequenceBuilder &builder, Params &params);
+    RandomGenerator(SequenceBuilder &builder, Params &params, std::bitset<CONFIG_STEP_COUNT> &selected);
 
     Mode mode() const override { return Mode::Random; }
 
@@ -64,4 +65,5 @@ public:
 private:
     Params &_params;
     GeneratorPattern _pattern;
+    std::bitset<CONFIG_STEP_COUNT> &_selected;
 };

--- a/src/apps/sequencer/model/BaseTrackPatternFollow.h
+++ b/src/apps/sequencer/model/BaseTrackPatternFollow.h
@@ -58,16 +58,23 @@ public:
     }
 
 
-    void togglePatternFollowDisplay() {
-        const auto pattern_follow = patternFollow();
+    void togglePatternFollowDisplay(bool isLaunchpadConnected = false) {
+        auto pattern_follow = patternFollow();
 
-        const bool disp_tracking = isPatternFollowDisplayOn();
+        if (isLaunchpadConnected) {
+            pattern_follow = static_cast<Types::PatternFollow>((static_cast<int>(pattern_follow) + 1) %4);
+        } else {
 
-        const bool lp_tracking =
-            (pattern_follow == Types::PatternFollow::LaunchPad ||
-             pattern_follow == Types::PatternFollow::DispAndLP);
+            if (pattern_follow == Types::PatternFollow::Off) {
+                pattern_follow = Types::PatternFollow::Display;
+            } else {
+                pattern_follow = Types::PatternFollow::Off;
+            }
+            
+        }
 
-        setPatternFollow(not disp_tracking, lp_tracking);
+
+        setPatternFollow(pattern_follow);
     }
 
     void editPatternFollow(int value, bool shift) {

--- a/src/apps/sequencer/model/Curve.cpp
+++ b/src/apps/sequencer/model/Curve.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <cmath>
+#include <map>
 
 static const float Pi = 3.1415926536f;
 static const float TwoPi = 2.f * Pi;

--- a/src/apps/sequencer/model/Curve.cpp
+++ b/src/apps/sequencer/model/Curve.cpp
@@ -7,6 +7,86 @@
 static const float Pi = 3.1415926536f;
 static const float TwoPi = 2.f * Pi;
 
+    static const std::map<int, Curve::Type> INV_SHAPE_MAP = {
+        {0, Curve::High},
+        {1, Curve::Low},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::RevTriangle},
+        {27, Curve::Triangle},
+        {28, Curve::RevBell},
+        {29, Curve::Bell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
+
+    static const std::map<int, Curve::Type> REV_SHAPE_MAP = {
+        {0, Curve::Low},
+        {1, Curve::High},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::Triangle},
+        {27, Curve::RevTriangle},
+        {28, Curve::Bell},
+        {29, Curve::RevBell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
+
 static float low(float x) {
     return 0.f;
 }
@@ -206,4 +286,12 @@ Curve::Function Curve::function(Type type) {
 
 float Curve::eval(Type type, float x) {
     return functions[type](x);
+}
+
+Curve::Type Curve::invAt(int i) {
+        return INV_SHAPE_MAP.at(i);
+}
+
+Curve::Type Curve::revAt(int i) {
+        return REV_SHAPE_MAP.at(i);
 }

--- a/src/apps/sequencer/model/Curve.cpp
+++ b/src/apps/sequencer/model/Curve.cpp
@@ -207,3 +207,11 @@ Curve::Function Curve::function(Type type) {
 float Curve::eval(Type type, float x) {
     return functions[type](x);
 }
+
+Curve::Type Curve::invAt(int i) {
+        return INV_SHAPE_MAP.at(i);
+}
+
+Curve::Type Curve::revAt(int i) {
+        return REV_SHAPE_MAP.at(i);
+}

--- a/src/apps/sequencer/model/Curve.cpp
+++ b/src/apps/sequencer/model/Curve.cpp
@@ -207,11 +207,3 @@ Curve::Function Curve::function(Type type) {
 float Curve::eval(Type type, float x) {
     return functions[type](x);
 }
-
-Curve::Type Curve::invAt(int i) {
-        return INV_SHAPE_MAP.at(i);
-}
-
-Curve::Type Curve::revAt(int i) {
-        return REV_SHAPE_MAP.at(i);
-}

--- a/src/apps/sequencer/model/Curve.h
+++ b/src/apps/sequencer/model/Curve.h
@@ -52,6 +52,9 @@ public:
     static Function function(Type type);
 
     static float eval(Type type, float x);
-}; 
+
+    static Type invAt(int i);
+    static Type revAt(int i);
+};
 
  

--- a/src/apps/sequencer/model/Curve.h
+++ b/src/apps/sequencer/model/Curve.h
@@ -2,6 +2,7 @@
 
 #include <map>
 class Curve {
+    
 public:
     typedef float (*Function)(float x);
 
@@ -53,9 +54,88 @@ public:
 
     static float eval(Type type, float x);
 
- 
-
-
+    static Type invAt(int i);
+    static Type revAt(int i);
 };
+
+    static const std::map<int, Curve::Type> INV_SHAPE_MAP = {
+        {0, Curve::High},
+        {1, Curve::Low},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::RevTriangle},
+        {27, Curve::Triangle},
+        {28, Curve::RevBell},
+        {29, Curve::Bell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
+
+        static const std::map<int, Curve::Type> REV_SHAPE_MAP = {
+        {0, Curve::Low},
+        {1, Curve::High},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::Triangle},
+        {27, Curve::RevTriangle},
+        {28, Curve::Bell},
+        {29, Curve::RevBell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
 
  

--- a/src/apps/sequencer/model/Curve.h
+++ b/src/apps/sequencer/model/Curve.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 class Curve {
     
 public:
@@ -53,89 +52,6 @@ public:
     static Function function(Type type);
 
     static float eval(Type type, float x);
-
-    static Type invAt(int i);
-    static Type revAt(int i);
-};
-
-    static const std::map<int, Curve::Type> INV_SHAPE_MAP = {
-        {0, Curve::High},
-        {1, Curve::Low},
-        {2, Curve::RampDown},
-        {3, Curve::RampUp},
-        {4, Curve::rampDownHalf},
-        {5, Curve::rampUpHalf},
-        {6, Curve::doubleRampDownHalf},
-        {7, Curve::doubleRampUpHalf},
-        {8, Curve::ExpDown},
-        {9, Curve::ExpUp},
-        {10, Curve::expDownHalf},
-        {11, Curve:: expUpHalf},
-        {12, Curve::doubleExpDownHalf},
-        {13, Curve::doubleExpUpHalf},
-        {14, Curve::LogDown},
-        {15, Curve::LogUp},
-        {16, Curve::logDownHalf},
-        {17, Curve::logUpHalf},
-        {18, Curve::doubleLogDownHalf},
-        {19, Curve::doubleLogUpHalf},
-        {20, Curve::SmoothDown},
-        {21, Curve::SmoothUp},
-        {22, Curve::smoothDownHalf},
-        {23, Curve::smoothUpHalf},
-        {24, Curve::doubleSmoothDownHalf},
-        {25, Curve::doubleSmoothUpHalf},
-        {26, Curve::RevTriangle},
-        {27, Curve::Triangle},
-        {28, Curve::RevBell},
-        {29, Curve::Bell},
-        {30, Curve::StepDown},
-        {31, Curve::StepUp},
-        {32, Curve::ExpUp2x},
-        {33, Curve::ExpDown2x},
-        {34, Curve::ExpUp3x},
-        {35, Curve::ExpUp4x},
-        {36, Curve::ExpDown4x}
-    };
-
-        static const std::map<int, Curve::Type> REV_SHAPE_MAP = {
-        {0, Curve::Low},
-        {1, Curve::High},
-        {2, Curve::RampDown},
-        {3, Curve::RampUp},
-        {4, Curve::rampDownHalf},
-        {5, Curve::rampUpHalf},
-        {6, Curve::doubleRampDownHalf},
-        {7, Curve::doubleRampUpHalf},
-        {8, Curve::ExpDown},
-        {9, Curve::ExpUp},
-        {10, Curve::expDownHalf},
-        {11, Curve:: expUpHalf},
-        {12, Curve::doubleExpDownHalf},
-        {13, Curve::doubleExpUpHalf},
-        {14, Curve::LogDown},
-        {15, Curve::LogUp},
-        {16, Curve::logDownHalf},
-        {17, Curve::logUpHalf},
-        {18, Curve::doubleLogDownHalf},
-        {19, Curve::doubleLogUpHalf},
-        {20, Curve::SmoothDown},
-        {21, Curve::SmoothUp},
-        {22, Curve::smoothDownHalf},
-        {23, Curve::smoothUpHalf},
-        {24, Curve::doubleSmoothDownHalf},
-        {25, Curve::doubleSmoothUpHalf},
-        {26, Curve::Triangle},
-        {27, Curve::RevTriangle},
-        {28, Curve::Bell},
-        {29, Curve::RevBell},
-        {30, Curve::StepDown},
-        {31, Curve::StepUp},
-        {32, Curve::ExpUp2x},
-        {33, Curve::ExpDown2x},
-        {34, Curve::ExpUp3x},
-        {35, Curve::ExpUp4x},
-        {36, Curve::ExpDown4x}
-    };
+}; 
 
  

--- a/src/apps/sequencer/model/CurveSequence.cpp
+++ b/src/apps/sequencer/model/CurveSequence.cpp
@@ -170,6 +170,18 @@ void CurveSequence::clear() {
     clearSteps();
 }
 
+void CurveSequence::clearStepsSelected(const std::bitset<CONFIG_STEP_COUNT> &selected) {
+    if (selected.any()) {
+        for (size_t i = 0; i < CONFIG_STEP_COUNT; ++i) {
+            if (selected[i]) {
+                _steps[i].clear();
+            }
+    }
+    } else {
+        clearSteps();
+    }
+}
+
 void CurveSequence::clearSteps() {
     for (auto &step : _steps) {
         step.clear();

--- a/src/apps/sequencer/model/CurveSequence.h
+++ b/src/apps/sequencer/model/CurveSequence.h
@@ -322,6 +322,8 @@ public:
 
     void clear();
     void clearSteps();
+    void clearStepsSelected(const std::bitset<CONFIG_STEP_COUNT> &selected);
+
 
     bool isEdited() const;
 

--- a/src/apps/sequencer/model/CurveTrack.cpp
+++ b/src/apps/sequencer/model/CurveTrack.cpp
@@ -38,6 +38,7 @@ void CurveTrack::clear() {
     }
 }
 
+
 void CurveTrack::write(VersionedSerializedWriter &writer) const {
     writer.write(_name, NameLength + 1);
     writer.write(_playMode);

--- a/src/apps/sequencer/model/CurveTrack.h
+++ b/src/apps/sequencer/model/CurveTrack.h
@@ -206,6 +206,10 @@ public:
     const CurveSequence &sequence(int index) const { return _sequences[index]; }
           CurveSequence &sequence(int index)       { return _sequences[index]; }
 
+    void setSequence(int index, CurveSequence seq) {
+        _sequences[index] = seq;
+    }
+
     //----------------------------------------
     // Routing
     //----------------------------------------

--- a/src/apps/sequencer/model/ModelUtils.h
+++ b/src/apps/sequencer/model/ModelUtils.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <algorithm>
 #include <bitset>
+#include <iostream>
 
 namespace ModelUtils {
 
@@ -73,12 +74,20 @@ static void shiftSteps(std::array<Step, N> &steps, const std::bitset<N> &selecte
         if (selected[i]) indices[count++] = i;
     }
     if (direction == 1) {
-        for (int i = count - 2; i >= 0; --i) {
-            std::swap(steps[indices[i]], steps[indices[i + 1]]);
+        for (int i = count - 1; i >= 0; --i) {
+            int index = indices[i]+1;
+            if (index == N) {
+                index = 0;
+            }
+            std::swap(steps[indices[i]], steps[index]);
         }
     } else if (direction == -1) {
-        for (int i = 0; i < count - 1; ++i) {
-            std::swap(steps[indices[i]], steps[indices[i + 1]]);
+        for (int i = 0; i < count; ++i) {
+            int index = indices[i]-1;
+            if (index == -1) {
+                index = N-1;
+            }
+            std::swap(steps[indices[i]], steps[index]);
         }
     }
 }

--- a/src/apps/sequencer/model/NoteSequence.cpp
+++ b/src/apps/sequencer/model/NoteSequence.cpp
@@ -219,6 +219,9 @@ void NoteSequence::Step::read(VersionedSerializedReader &reader) {
     } else {
         reader.read(_data0.raw);
         reader.read(_data1.raw);
+        if (reader.dataVersion() < ProjectVersion::Version34) {
+            setBypassScale(false);
+        }
     }
 }
 

--- a/src/apps/sequencer/model/NoteSequence.cpp
+++ b/src/apps/sequencer/model/NoteSequence.cpp
@@ -256,6 +256,18 @@ void NoteSequence::clearSteps() {
     }
 }
 
+void NoteSequence::clearStepsSelected(const std::bitset<CONFIG_STEP_COUNT> &selected) {
+    if (selected.any()) {
+        for (size_t i = 0; i < CONFIG_STEP_COUNT; ++i) {
+            if (selected[i]) {
+                _steps[i].clear();
+            }
+    }
+    } else {
+        clearSteps();
+    }
+}
+
 bool NoteSequence::isEdited() const {
     auto clearStep = Step();
     for (const auto &step : _steps) {

--- a/src/apps/sequencer/model/NoteSequence.cpp
+++ b/src/apps/sequencer/model/NoteSequence.cpp
@@ -13,6 +13,8 @@ Types::LayerRange NoteSequence::layerRange(Layer layer) {
         return { 0, 1 };
     case Layer::Slide:
         return { 0, 1 };
+    case Layer::BypassScale:
+        return {0 ,1 };
     CASE(GateOffset)
     CASE(GateProbability)
     CASE(Retrigger)
@@ -48,6 +50,8 @@ int NoteSequence::layerDefaultValue(Layer layer)
         return step.gateOffset();
     case Layer::Slide:
         return step.slide();
+    case Layer::BypassScale:
+        return step.bypassScale();
     case Layer::Retrigger:
         return step.retrigger();
     case Layer::RetriggerProbability:
@@ -83,6 +87,8 @@ int NoteSequence::Step::layerValue(Layer layer) const {
         return gate() ? 1 : 0;
     case Layer::Slide:
         return slide() ? 1 : 0;
+    case Layer::BypassScale:
+        return bypassScale() ? 1 : 0;
     case Layer::GateProbability:
         return gateProbability();
     case Layer::GateOffset:
@@ -123,6 +129,9 @@ void NoteSequence::Step::setLayerValue(Layer layer, int value) {
         break;
     case Layer::Slide:
         setSlide(value);
+        break;
+    case Layer::BypassScale:
+        setBypassScale(value);
         break;
     case Layer::GateProbability:
         setGateProbability(value);
@@ -175,6 +184,7 @@ void NoteSequence::Step::clear() {
     setGateProbability(GateProbability::Max);
     setGateOffset(0);
     setSlide(false);
+    setBypassScale(false);
     setRetrigger(0);
     setRetriggerProbability(RetriggerProbability::Max);
     setLength(Length::Max / 2);

--- a/src/apps/sequencer/model/NoteSequence.h
+++ b/src/apps/sequencer/model/NoteSequence.h
@@ -55,6 +55,7 @@ public:
         NoteVariationRange,
         NoteVariationProbability,
         Slide,
+        BypassScale,
         Condition,
         Last
     };
@@ -65,6 +66,7 @@ public:
         case Layer::GateProbability:            return "GATE PROB";
         case Layer::GateOffset:                 return "GATE OFFSET";
         case Layer::Slide:                      return "SLIDE";
+        case Layer::BypassScale:                 return "BYPASS SCALE";
         case Layer::Retrigger:                  return "RETRIG";
         case Layer::RetriggerProbability:       return "RETRIG PROB";
         case Layer::Length:                     return "LENGTH";
@@ -214,6 +216,14 @@ public:
         int layerValue(Layer layer) const;
         void setLayerValue(Layer layer, int value);
 
+        bool bypassScale() const { return _data0.bypassScale ? true : false; }
+        void setBypassScale(bool bypass) {
+            _data0.bypassScale = bypass;
+        }
+        void toggleBypassScale() {
+            setBypassScale(!bypassScale());
+        }
+
         //----------------------------------------
         // Methods
         //----------------------------------------
@@ -244,7 +254,7 @@ public:
             BitField<uint32_t, 13, Note::Bits> note;
             BitField<uint32_t, 20, NoteVariationRange::Bits> noteVariationRange;
             BitField<uint32_t, 27, NoteVariationProbability::Bits> noteVariationProbability;
-            // 1 bits left
+            BitField<uint32_t, 31, 1> bypassScale;
         } _data0;
         union {
             uint32_t raw;

--- a/src/apps/sequencer/model/NoteSequence.h
+++ b/src/apps/sequencer/model/NoteSequence.h
@@ -495,6 +495,7 @@ public:
 
     void clear();
     void clearSteps();
+    void clearStepsSelected(const std::bitset<CONFIG_STEP_COUNT> &selected);
 
     bool isEdited() const;
 

--- a/src/apps/sequencer/model/NoteTrack.cpp
+++ b/src/apps/sequencer/model/NoteTrack.cpp
@@ -54,6 +54,7 @@ void NoteTrack::clear() {
     }
 }
 
+
 void NoteTrack::write(VersionedSerializedWriter &writer) const {
     writer.write(_name, NameLength + 1);
     writer.write(_playMode);

--- a/src/apps/sequencer/model/NoteTrack.h
+++ b/src/apps/sequencer/model/NoteTrack.h
@@ -273,6 +273,10 @@ public:
     const NoteSequence &sequence(int index) const { return _sequences[index]; }
           NoteSequence &sequence(int index)       { return _sequences[index]; }
 
+    void setSequence(int index, NoteSequence seq) {
+        _sequences[index] = seq;
+    }
+
     //----------------------------------------
     // Routing
     //----------------------------------------

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -458,6 +458,10 @@ public:
     const NoteSequence &selectedNoteSequence() const { return noteSequence(_selectedTrackIndex, selectedPatternIndex()); }
           NoteSequence &selectedNoteSequence()       { return noteSequence(_selectedTrackIndex, selectedPatternIndex()); }
 
+    void setSelectedNoteSequence(NoteSequence seq) {
+        _tracks[_selectedTrackIndex].noteTrack().setSequence(selectedPatternIndex(), seq);
+    }
+
     // curveSequence
 
     const CurveSequence &curveSequence(int trackIndex, int patternIndex) const { return _tracks[trackIndex].curveTrack().sequence(patternIndex); }

--- a/src/apps/sequencer/model/Project.h
+++ b/src/apps/sequencer/model/Project.h
@@ -443,6 +443,10 @@ public:
     CurveSequence::Layer selectedCurveSequenceLayer() const { return _selectedCurveSequenceLayer; }
     void setSelectedCurveSequenceLayer(CurveSequence::Layer layer) { _selectedCurveSequenceLayer = layer; }
 
+    void setSelectedCurveSequence(CurveSequence seq) {
+        _tracks[_selectedTrackIndex].curveTrack().setSequence(selectedPatternIndex(), seq);
+    }
+
     // selectedTrack
 
     const Track &selectedTrack() const { return _tracks[_selectedTrackIndex]; }

--- a/src/apps/sequencer/model/ProjectVersion.h
+++ b/src/apps/sequencer/model/ProjectVersion.h
@@ -96,6 +96,9 @@ enum ProjectVersion {
     // added Track::name and expand noteRetrigger to 3 bits and nprobability to 6bits
     Version33 = 33,
 
+    // add bypass scale
+    Version34 = 34,
+
     // automatically derive latest version
     Last,
     Latest = Last - 1,

--- a/src/apps/sequencer/model/Settings.h
+++ b/src/apps/sequencer/model/Settings.h
@@ -18,6 +18,10 @@ public:
     const UserSettings &userSettings() const { return _userSettings; }
           UserSettings &userSettings()       { return _userSettings; }
 
+    
+    const LaunchpadSettings &launchpadSettings() const { return _launchpadSettings; }
+          LaunchpadSettings &launchpadSettings()       { return _launchpadSettings; }
+
     void clear();
 
     void write(VersionedSerializedWriter &writer) const;
@@ -29,4 +33,5 @@ public:
 private:
     Calibration _calibration;
     UserSettings _userSettings;
+    LaunchpadSettings _launchpadSettings;
 };

--- a/src/apps/sequencer/model/UserSettings.h
+++ b/src/apps/sequencer/model/UserSettings.h
@@ -198,9 +198,9 @@ public:
         addSetting(new ScreensaverSetting());
         addSetting(new WakeModeSetting());
         addSetting(new DimSequenceSetting());
-        addSetting(new LaunchpadStyleSetting());
+        
         addSetting(new PatternChange());
-        addSetting(new LaunchpadNoteStyle());
+        
         addSetting(new SyncSong());
     }
 
@@ -219,7 +219,7 @@ public:
     void write(VersionedSerializedWriter &writer) const;
     void read(VersionedSerializedReader &reader);
 
-private:
+protected:
     std::vector<BaseSetting *> _settings;
 
     template<typename T>
@@ -227,4 +227,13 @@ private:
         _settings.push_back(setting);
     }
     BaseSetting *_get(const std::string &key);
+
+};
+
+class LaunchpadSettings : public UserSettings{
+    public: 
+        LaunchpadSettings() {
+            addSetting(new LaunchpadStyleSetting());
+            addSetting(new LaunchpadNoteStyle());
+        }
 };

--- a/src/apps/sequencer/ui/ControllerManager.cpp
+++ b/src/apps/sequencer/ui/ControllerManager.cpp
@@ -1,26 +1,5 @@
 #include "ControllerManager.h"
 
-static const ControllerInfo controllerInfos[] = {
-    { 0x1235, 0x0020, ControllerInfo::Type::Launchpad },    // Novation Launchpad S
-    { 0x1235, 0x0036, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk1
-    { 0x1235, 0x0037, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk2
-    { 0x1235, 0x0069, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mk2
-    { 0x1235, 0x0051, ControllerInfo::Type::Launchpad },    // Novation Launchpad Pro
-    { 0x1235, 0x0113, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk3
-    { 0x1235, 0x0103, ControllerInfo::Type::Launchpad },    // Novation Launchpad X
-    { 0x1235, 0x0123, ControllerInfo::Type::Launchpad },    // Novation Launchpad Pro Mk3
-};
-
-static const ControllerInfo *findController(uint16_t vendorId, uint16_t productId) {
-    for (size_t i = 0; i < sizeof(controllerInfos) / sizeof(controllerInfos[0]); ++i) {
-        auto info = &controllerInfos[i];
-        if (info->vendorId == vendorId && info->productId == productId) {
-            return info;
-        }
-    }
-    return nullptr;
-}
-
 
 ControllerManager::ControllerManager(Model &model, Engine &engine) :
     _model(model),

--- a/src/apps/sequencer/ui/ControllerManager.h
+++ b/src/apps/sequencer/ui/ControllerManager.h
@@ -11,7 +11,21 @@
 #include "core/midi/MidiMessage.h"
 #include "core/utils/Container.h"
 
+    static const ControllerInfo controllerInfos[] = {
+        { 0x1235, 0x0020, ControllerInfo::Type::Launchpad },    // Novation Launchpad S
+        { 0x1235, 0x0036, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk1
+        { 0x1235, 0x0037, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk2
+        { 0x1235, 0x0069, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mk2
+        { 0x1235, 0x0051, ControllerInfo::Type::Launchpad },    // Novation Launchpad Pro
+        { 0x1235, 0x0113, ControllerInfo::Type::Launchpad },    // Novation Launchpad Mini Mk3
+        { 0x1235, 0x0103, ControllerInfo::Type::Launchpad },    // Novation Launchpad X
+        { 0x1235, 0x0123, ControllerInfo::Type::Launchpad },    // Novation Launchpad Pro Mk3
+    };
+
 class ControllerManager {
+
+
+
 public:
     ControllerManager(Model &model, Engine &engine);
 
@@ -25,6 +39,16 @@ public:
     int fps() const { return 50; }
 
     bool recvMidi(MidiPort port, uint8_t cable, const MidiMessage &message);
+
+    static const ControllerInfo *findController(uint16_t vendorId, uint16_t productId) {
+        for (size_t i = 0; i < sizeof(controllerInfos) / sizeof(controllerInfos[0]); ++i) {
+            auto info = &controllerInfos[i];
+            if (info->vendorId == vendorId && info->productId == productId) {
+                return info;
+            }
+        }
+        return nullptr;
+    }
 
 private:
     bool sendMidi(uint8_t cable, const MidiMessage &message);

--- a/src/apps/sequencer/ui/StepSelection.h
+++ b/src/apps/sequencer/ui/StepSelection.h
@@ -109,6 +109,23 @@ public:
         _first = 0;
     }
 
+    void shiftLeft() {
+        rotateL(_selected, 1);
+    }
+
+    void shiftRight() {
+        rotateR(_selected, 1);
+
+    }
+
+    inline void rotateR(std::bitset<N>& b, unsigned m) {
+        b = b << m | b >> (N-m);
+    }
+
+    inline void rotateL(std::bitset<N>& b, unsigned m) {
+        b = b >> m | b << (N-m);
+    }
+
     void selectEqualSteps(int stepIndex) {
         _mode = Mode::Persist;
         for (int i = 0; i < int(_selected.size()); ++i) {

--- a/src/apps/sequencer/ui/StepSelection.h
+++ b/src/apps/sequencer/ui/StepSelection.h
@@ -147,6 +147,10 @@ public:
         return _first;
     }
 
+    int at(int index) const {
+        return _selected[index];
+    }
+
     int firstSetIndex() const {
         for (size_t i = 0; i < _selected.size(); ++i) {
             if (_selected[i]) {
@@ -183,6 +187,7 @@ public:
     }
 
     const std::bitset<N> &selected() const { return _selected; }
+    std::bitset<N> &selected() { return _selected; }
 
     bool operator[](int index) const {
         return _selected[index];

--- a/src/apps/sequencer/ui/controllers/launchpad/LaunchpadController.cpp
+++ b/src/apps/sequencer/ui/controllers/launchpad/LaunchpadController.cpp
@@ -106,7 +106,7 @@ static const RangeMap *curveSequenceLayerRangeMap[] = {
     [int(CurveSequence::Layer::GateProbability)]            = nullptr,
 };
 
-UserSettings _userSettings;
+LaunchpadSettings _userSettings;
 int _style = 0;
 int _patternChangeDefault = 0;
 int _noteStyle = 0;
@@ -157,7 +157,7 @@ LaunchpadController::LaunchpadController(ControllerManager &manager, Model &mode
 
     setMode(Mode::Sequence);
 
-    _userSettings = model.settings().userSettings();
+    _userSettings = model.settings().launchpadSettings();
 }
 
 LaunchpadController::~LaunchpadController() {

--- a/src/apps/sequencer/ui/controllers/launchpad/LaunchpadController.cpp
+++ b/src/apps/sequencer/ui/controllers/launchpad/LaunchpadController.cpp
@@ -64,6 +64,7 @@ static const LayerMapItem noteSequenceLayerMap[] = {
     [int(NoteSequence::Layer::NoteVariationRange)]          =  { 1, 3 },
     [int(NoteSequence::Layer::NoteVariationProbability)]    =  { 2, 3 },
     [int(NoteSequence::Layer::Slide)]                       =  { 3, 3 },
+    [int(NoteSequence::Layer::BypassScale)]                 =  { 4, 3 },
     [int(NoteSequence::Layer::Condition)]                   =  { 0, 4 },
 
 

--- a/src/apps/sequencer/ui/model/ContextMenuModel.h
+++ b/src/apps/sequencer/ui/model/ContextMenuModel.h
@@ -13,4 +13,5 @@ public:
 
     virtual const Item &item(int index) const = 0;
     virtual bool itemEnabled(int index) const = 0;
+    virtual bool doubleClick() const = 0;
 };

--- a/src/apps/sequencer/ui/model/SettingsListModel.h
+++ b/src/apps/sequencer/ui/model/SettingsListModel.h
@@ -37,3 +37,35 @@ public:
 private:
     UserSettings &_userSettings;
 };
+
+class LpSettingsListModel : public ListModel {
+public:
+    LpSettingsListModel(LaunchpadSettings &userSettings) :
+        _launchpadSettings(userSettings)
+    {}
+
+    int rows() const override {
+        return _launchpadSettings.all().size();
+    }
+
+    int columns() const override {
+        return 2;
+    }
+
+    void cell(int row, int column, StringBuilder &str) const override {
+        if (column == 0) {
+            str("%s", _launchpadSettings.get(row)->getMenuItem().c_str());
+        } else if (column == 1) {
+            str("%s", _launchpadSettings.get(row)->getMenuItemKey().c_str());
+        }
+    }
+
+    void edit(int row, int column, int value, bool shift) override {
+        if (column == 1) {
+            _launchpadSettings.shift(row, value);
+        }
+    }
+
+private:
+    LaunchpadSettings &_launchpadSettings;
+};

--- a/src/apps/sequencer/ui/pages/ContextMenu.h
+++ b/src/apps/sequencer/ui/pages/ContextMenu.h
@@ -15,16 +15,21 @@ public:
         const Item items[],
         int itemCount,
         ActionCallback actionCallback,
-        ItemEnabledCallback itemEnabledCallback = [] (int) { return true; }
+        ItemEnabledCallback itemEnabledCallback = [] (int) { return true; }, bool doubleClick = false
     ) :
         _items(items),
         _itemCount(itemCount),
         _actionCallback(actionCallback),
-        _itemEnabledCallback(itemEnabledCallback)
+        _itemEnabledCallback(itemEnabledCallback),
+        _doubleClick(doubleClick)
     {
     }
 
     const ActionCallback &actionCallback() const { return _actionCallback; }
+
+    virtual bool doubleClick() const override{
+        return _doubleClick;
+    }
 
 private:
     virtual int itemCount() const override {
@@ -43,4 +48,5 @@ private:
     int _itemCount;
     ActionCallback _actionCallback;
     ItemEnabledCallback _itemEnabledCallback;
+    bool _doubleClick = false;
 };

--- a/src/apps/sequencer/ui/pages/ContextMenuPage.cpp
+++ b/src/apps/sequencer/ui/pages/ContextMenuPage.cpp
@@ -3,18 +3,31 @@
 #include "ui/painters/WindowPainter.h"
 
 #include "core/math/Math.h"
+#include <cstdint>
 
 ContextMenuPage::ContextMenuPage(PageManager &manager, PageContext &context) :
     BasePage(manager, context)
-{}
+{}    
+
+uint32_t lastTicks;
 
 void ContextMenuPage::show(ContextMenuModel &contextMenuModel, ResultCallback callback) {
     _contextMenuModel = &contextMenuModel;
     _callback = callback;
+    lastTicks = os::ticks();
     BasePage::show();
 }
 
 void ContextMenuPage::draw(Canvas &canvas) {
+
+
+    uint32_t currentTicks = os::ticks();
+    uint32_t deltaTicks = currentTicks - lastTicks;
+    if (deltaTicks > os::time::ms(2000)) {
+        close();
+    }
+
+
     canvas.setFont(Font::Tiny);
     canvas.setBlendMode(BlendMode::Set);
 
@@ -53,6 +66,9 @@ void ContextMenuPage::draw(Canvas &canvas) {
 void ContextMenuPage::keyUp(KeyEvent &event) {
     const auto &key = event.key();
 
+    if (_contextMenuModel->doubleClick()) {
+        return;
+    }
     if (!key.pageModifier() || !key.shiftModifier()) {
         close();
         event.consume();

--- a/src/apps/sequencer/ui/pages/ContextMenuPage.cpp
+++ b/src/apps/sequencer/ui/pages/ContextMenuPage.cpp
@@ -23,7 +23,7 @@ void ContextMenuPage::draw(Canvas &canvas) {
 
     uint32_t currentTicks = os::ticks();
     uint32_t deltaTicks = currentTicks - lastTicks;
-    if (deltaTicks > os::time::ms(2000)) {
+    if (deltaTicks > os::time::ms(2000) && _contextMenuModel->doubleClick()) {
         close();
     }
 

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -685,7 +685,7 @@ bool CurveSequenceEditPage::contextActionEnabled(int index) const {
 }
 
 void CurveSequenceEditPage::initSequence() {
-    _project.selectedCurveSequence().clearSteps();
+    _project.selectedCurveSequence().clearStepsSelected(_stepSelection.selected());
     showMessage("STEPS INITIALIZED");
 }
 

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -177,7 +177,7 @@ void CurveSequenceEditPage::draw(Canvas &canvas) {
     WindowPainter::drawActiveFunction(canvas, CurveSequence::layerName(layer()));
     WindowPainter::drawFooter(canvas, functionNames, pageKeyState(), activeFunctionKey());
 
-    const auto &trackEngine = _engine.selectedTrackEngine().as<CurveTrackEngine>();
+    auto &trackEngine = _engine.selectedTrackEngine().as<CurveTrackEngine>();
     const auto &sequence = _project.selectedCurveSequence();
     int currentStep = trackEngine.isActiveSequence(sequence) ? trackEngine.currentStep() : -1;
 
@@ -314,7 +314,18 @@ void CurveSequenceEditPage::draw(Canvas &canvas) {
     // draw cursor
     if (isActiveSequence) {
         canvas.setColor(Color::Bright);
-        int x = ((trackEngine.currentStep() - stepOffset) + trackEngine.currentStepFraction()) * stepWidth;
+
+        int x;
+
+
+        auto dir = trackEngine.sequenceState().direction();
+        std::cerr << dir << "\n";
+        if (dir == 1) {
+            x = ((trackEngine.currentStep() - stepOffset) + trackEngine.currentStepFraction()) * stepWidth;
+        } else if (dir == -1) {
+            x = ((trackEngine.currentStep() + stepOffset)- trackEngine.currentStepFraction()) * stepWidth;
+        }
+
         canvas.vline(x, curveY, curveHeight);
     }
 

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -316,10 +316,7 @@ void CurveSequenceEditPage::draw(Canvas &canvas) {
         canvas.setColor(Color::Bright);
 
         int x;
-
-
         auto dir = trackEngine.sequenceState().direction();
-        std::cerr << dir << "\n";
         if (dir == 1) {
             x = ((trackEngine.currentStep() - stepOffset) + trackEngine.currentStepFraction()) * stepWidth;
         } else if (dir == -1) {
@@ -389,6 +386,12 @@ void CurveSequenceEditPage::keyPress(KeyPressEvent &event) {
 
     if (key.isContextMenu()) {
         contextShow();
+        event.consume();
+        return;
+    }
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
         event.consume();
         return;
     }
@@ -681,12 +684,13 @@ void CurveSequenceEditPage::drawDetail(Canvas &canvas, const CurveSequence::Step
     }
 }
 
-void CurveSequenceEditPage::contextShow() {
+void CurveSequenceEditPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -36,46 +36,6 @@ enum class Function {
     Gate    = 3,
 };
 
-static const std::map<int, Curve::Type> _shapeMap = {
-        {0, Curve::High},
-        {1, Curve::Low},
-        {2, Curve::RampDown},
-        {3, Curve::RampUp},
-        {4, Curve::rampDownHalf},
-        {5, Curve::rampUpHalf},
-        {6, Curve::doubleRampDownHalf},
-        {7, Curve::doubleRampUpHalf},
-        {8, Curve::ExpDown},
-        {9, Curve::ExpUp},
-        {10, Curve::expDownHalf},
-        {11, Curve:: expUpHalf},
-        {12, Curve::doubleExpDownHalf},
-        {13, Curve::doubleExpUpHalf},
-        {14, Curve::LogDown},
-        {15, Curve::LogUp},
-        {16, Curve::logDownHalf},
-        {17, Curve::logUpHalf},
-        {18, Curve::doubleLogDownHalf},
-        {19, Curve::doubleLogUpHalf},
-        {20, Curve::SmoothDown},
-        {21, Curve::SmoothUp},
-        {22, Curve::smoothDownHalf},
-        {23, Curve::smoothUpHalf},
-        {24, Curve::doubleSmoothDownHalf},
-        {25, Curve::doubleSmoothUpHalf},
-        {26, Curve::RevTriangle},
-        {27, Curve::Triangle},
-        {28, Curve::RevBell},
-        {29, Curve::Bell},
-        {30, Curve::StepDown},
-        {31, Curve::StepUp},
-        {32, Curve::ExpUp2x},
-        {33, Curve::ExpDown2x},
-        {34, Curve::ExpUp3x},
-        {35, Curve::ExpUp4x},
-        {36, Curve::ExpDown4x}
-    };
-
 static const char *functionNames[] = { "SHAPE", "MIN", "MAX", "GATE", nullptr };
 
 static const CurveSequenceListModel::Item quickEditItems[8] = {
@@ -407,12 +367,11 @@ void CurveSequenceEditPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
-
     if (key.isEncoder() && layer() == Layer::Shape && globalKeyState()[Key::Shift] && _stepSelection.count() > 1) {
         for (size_t stepIndex = 0; stepIndex < _stepSelection.size(); ++stepIndex) {
         if (_stepSelection[stepIndex]) {
             auto &step = sequence.step(stepIndex);
-            auto reverseShape = _shapeMap.at(step.shape());
+            auto reverseShape = Curve::invAt(step.shape());
             step.setShape(reverseShape);
         }
     }

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -735,9 +735,12 @@ void CurveSequenceEditPage::generateSequence() {
     _manager.pages().generatorSelect.show([this] (bool success, Generator::Mode mode) {
         if (success) {
             auto builder = _builderContainer.create<CurveSequenceBuilder>(_project.selectedCurveSequence(), layer());
-            auto generator = Generator::execute(mode, *builder);
+            if (_stepSelection.none()) {
+                _stepSelection.selectAll();
+            }
+            auto generator = Generator::execute(mode, *builder, _stepSelection.selected());
             if (generator) {
-                _manager.pages().generator.show(generator);
+                _manager.pages().generator.show(generator, &_stepSelection);
             }
         }
     });

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.cpp
@@ -38,6 +38,46 @@ enum class Function {
 
 static const char *functionNames[] = { "SHAPE", "MIN", "MAX", "GATE", nullptr };
 
+static const std::map<int, Curve::Type> INV_SHAPE_MAP = {
+        {0, Curve::High},
+        {1, Curve::Low},
+        {2, Curve::RampDown},
+        {3, Curve::RampUp},
+        {4, Curve::rampDownHalf},
+        {5, Curve::rampUpHalf},
+        {6, Curve::doubleRampDownHalf},
+        {7, Curve::doubleRampUpHalf},
+        {8, Curve::ExpDown},
+        {9, Curve::ExpUp},
+        {10, Curve::expDownHalf},
+        {11, Curve:: expUpHalf},
+        {12, Curve::doubleExpDownHalf},
+        {13, Curve::doubleExpUpHalf},
+        {14, Curve::LogDown},
+        {15, Curve::LogUp},
+        {16, Curve::logDownHalf},
+        {17, Curve::logUpHalf},
+        {18, Curve::doubleLogDownHalf},
+        {19, Curve::doubleLogUpHalf},
+        {20, Curve::SmoothDown},
+        {21, Curve::SmoothUp},
+        {22, Curve::smoothDownHalf},
+        {23, Curve::smoothUpHalf},
+        {24, Curve::doubleSmoothDownHalf},
+        {25, Curve::doubleSmoothUpHalf},
+        {26, Curve::RevTriangle},
+        {27, Curve::Triangle},
+        {28, Curve::RevBell},
+        {29, Curve::Bell},
+        {30, Curve::StepDown},
+        {31, Curve::StepUp},
+        {32, Curve::ExpUp2x},
+        {33, Curve::ExpDown2x},
+        {34, Curve::ExpUp3x},
+        {35, Curve::ExpUp4x},
+        {36, Curve::ExpDown4x}
+    };
+
 
 static const CurveSequenceListModel::Item quickEditItems[8] = {
     CurveSequenceListModel::Item::FirstStep,
@@ -278,7 +318,7 @@ void CurveSequenceEditPage::draw(Canvas &canvas) {
     if (isActiveSequence) {
         canvas.setColor(Color::Bright);
 
-        int x;
+        int x = 0;
         auto dir = trackEngine.sequenceState().direction();
         if (dir == 1) {
             x = ((trackEngine.currentStep() - stepOffset) + trackEngine.currentStepFraction()) * stepWidth;
@@ -384,7 +424,7 @@ void CurveSequenceEditPage::keyPress(KeyPressEvent &event) {
         for (size_t stepIndex = 0; stepIndex < _stepSelection.size(); ++stepIndex) {
         if (_stepSelection[stepIndex]) {
             auto &step = sequence.step(stepIndex);
-            auto reverseShape = Curve::invAt(step.shape());
+            auto reverseShape = INV_SHAPE_MAP.at(step.shape());
             step.setShape(reverseShape);
         }
     }

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
@@ -38,7 +38,7 @@ private:
 
     void drawDetail(Canvas &canvas, const CurveSequence::Step &step);
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/CurveSequenceEditPage.h
@@ -64,4 +64,6 @@ private:
     StepSelection<CONFIG_STEP_COUNT> _stepSelection;
 
     Container<CurveSequenceBuilder> _builderContainer;
+
+    CurveSequence _inMemorySequence;
 };

--- a/src/apps/sequencer/ui/pages/CurveSequencePage.cpp
+++ b/src/apps/sequencer/ui/pages/CurveSequencePage.cpp
@@ -58,6 +58,13 @@ void CurveSequencePage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -67,12 +74,13 @@ void CurveSequencePage::keyPress(KeyPressEvent &event) {
     }
 }
 
-void CurveSequencePage::contextShow() {
+void CurveSequencePage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/CurveSequencePage.h
+++ b/src/apps/sequencer/ui/pages/CurveSequencePage.h
@@ -17,7 +17,7 @@ public:
     virtual void keyPress(KeyPressEvent &event) override;
 
 private:
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/GeneratorPage.cpp
+++ b/src/apps/sequencer/ui/pages/GeneratorPage.cpp
@@ -213,7 +213,11 @@ void GeneratorPage::drawRandomGenerator(Canvas &canvas, const RandomGenerator &g
     for (int i = 0; i < steps; ++i) {
         int h = stepHeight - 2;
         int h2 = (h * pattern[i]) / 255;
-        canvas.setColor(Color::Low);
+        if ( i / 16 == _section ) {
+            canvas.setColor(Color::Medium);
+        } else {
+            canvas.setColor(Color::Low);
+        }
         canvas.drawRect(x + 1, y + 1, stepWidth - 2, h);
         canvas.setColor(Color::Bright);
         canvas.hline(x + 1, y + 1 + h - h2, stepWidth - 2);

--- a/src/apps/sequencer/ui/pages/GeneratorPage.cpp
+++ b/src/apps/sequencer/ui/pages/GeneratorPage.cpp
@@ -138,6 +138,13 @@ void GeneratorPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.isGlobal()) {
         return;
     }
@@ -235,12 +242,13 @@ void GeneratorPage::drawRandomGenerator(Canvas &canvas, const RandomGenerator &g
     }
 }
 
-void GeneratorPage::contextShow() {
+void GeneratorPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/GeneratorPage.h
+++ b/src/apps/sequencer/ui/pages/GeneratorPage.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "BasePage.h"
+#include "ui/StepSelection.h"
+#include "engine/generators/SequenceBuilder.h"
 
 class Generator;
 class EuclideanGenerator;
@@ -11,7 +13,7 @@ public:
     GeneratorPage(PageManager &manager, PageContext &context);
 
     using BasePage::show;
-    void show(Generator *generator);
+    void show(Generator *generator, StepSelection<CONFIG_STEP_COUNT> *_stepSelection);
 
     virtual void enter() override;
     virtual void exit() override;
@@ -25,6 +27,10 @@ public:
     virtual void keyUp(KeyEvent &event) override;
     virtual void keyPress(KeyPressEvent &event) override;
     virtual void encoder(EncoderEvent &event) override;
+
+        static const int StepCount = 16;
+
+    int stepOffset() const { return _section * StepCount; }
 
     void contextShow();
     void contextAction(int index);
@@ -40,4 +46,8 @@ private:
     Generator *_generator;
 
     std::pair<uint8_t, uint8_t> _valueRange;
+    StepSelection<CONFIG_STEP_COUNT> *_stepSelection;
+    int _section = 0;
+
+    Container<NoteSequenceBuilder> _builderContainer;
 };

--- a/src/apps/sequencer/ui/pages/GeneratorPage.h
+++ b/src/apps/sequencer/ui/pages/GeneratorPage.h
@@ -32,7 +32,7 @@ public:
 
     int stepOffset() const { return _section * StepCount; }
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
     void init();

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -333,6 +333,11 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
         event.consume();
         return;
     }
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
 
     if (key.isQuickEdit()) {
          if (key.is(Key::Step15)) {
@@ -887,12 +892,12 @@ void NoteSequenceEditPage::drawDetail(Canvas &canvas, const NoteSequence::Step &
     }
 }
 
-void NoteSequenceEditPage::contextShow() {
+void NoteSequenceEditPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); }, doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -396,6 +396,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     if (key.isLeft()) {
         if (key.shiftModifier()) {
             sequence.shiftSteps(_stepSelection.selected(), -1);
+            _stepSelection.shiftLeft();
         } else {
             track.setPatternFollowDisplay(false);
             _section = std::max(0, _section - 1);
@@ -405,6 +406,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     if (key.isRight()) {
         if (key.shiftModifier()) {
             sequence.shiftSteps(_stepSelection.selected(), 1);
+            _stepSelection.shiftRight();
         } else {
             track.setPatternFollowDisplay(false);
             _section = std::min(3, _section + 1);

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -12,6 +12,7 @@
 #include "os/os.h"
 
 #include "core/utils/StringBuilder.h"
+#include <bitset>
 #include <iostream>
 
 enum class ContextAction {
@@ -980,9 +981,14 @@ void NoteSequenceEditPage::generateSequence() {
     _manager.pages().generatorSelect.show([this] (bool success, Generator::Mode mode) {
         if (success) {
             auto builder = _builderContainer.create<NoteSequenceBuilder>(_project.selectedNoteSequence(), layer());
-            auto generator = Generator::execute(mode, *builder);
+
+            if (_stepSelection.none()) {
+                _stepSelection.selectAll();
+            }
+
+            auto generator = Generator::execute(mode, *builder, _stepSelection.selected());
             if (generator) {
-                _manager.pages().generator.show(generator);
+                _manager.pages().generator.show(generator, &_stepSelection);
             }
         }
     });

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -12,6 +12,7 @@
 #include "os/os.h"
 
 #include "core/utils/StringBuilder.h"
+#include <iostream>
 
 enum class ContextAction {
     Init,
@@ -334,7 +335,9 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
 
     if (key.isQuickEdit()) {
          if (key.is(Key::Step15)) {
-             track.togglePatternFollowDisplay();
+            bool lpConnected = _engine.isLaunchpadConnected();
+
+             track.togglePatternFollowDisplay(lpConnected);
         } else {
             quickEdit(key.quickEdit());
         }

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -438,6 +438,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
 
     if (key.isLeft()) {
         if (key.shiftModifier()) {
+            _inMemorySequence = _project.selectedNoteSequence();
             sequence.shiftSteps(_stepSelection.selected(), -1);
             _stepSelection.shiftLeft();
         } else {
@@ -448,6 +449,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     }
     if (key.isRight()) {
         if (key.shiftModifier()) {
+            _inMemorySequence = _project.selectedNoteSequence();
             sequence.shiftSteps(_stepSelection.selected(), 1);
             _stepSelection.shiftRight();
         } else {

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -924,7 +924,7 @@ bool NoteSequenceEditPage::contextActionEnabled(int index) const {
 }
 
 void NoteSequenceEditPage::initSequence() {
-    _project.selectedNoteSequence().clearSteps();
+    _project.selectedNoteSequence().clearStepsSelected(_stepSelection.selected());
     showMessage("STEPS INITIALIZED");
 }
 

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -42,7 +42,6 @@ enum class Function {
 
 static const char *functionNames[] = { "GATE", "RETRIG", "LENGTH", "NOTE", "COND" };
 
-NoteSequence _inMemorySequence;
 
 static const NoteSequenceListModel::Item quickEditItems[8] = {
     NoteSequenceListModel::Item::FirstStep,
@@ -369,6 +368,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
 
              track.togglePatternFollowDisplay(lpConnected);
         } else {
+            _inMemorySequence = _project.selectedNoteSequence();
             quickEdit(key.quickEdit());
         }
         event.consume();

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.cpp
@@ -41,6 +41,8 @@ enum class Function {
 
 static const char *functionNames[] = { "GATE", "RETRIG", "LENGTH", "NOTE", "COND" };
 
+NoteSequence _inMemorySequence;
+
 static const NoteSequenceListModel::Item quickEditItems[8] = {
     NoteSequenceListModel::Item::FirstStep,
     NoteSequenceListModel::Item::LastStep,
@@ -64,6 +66,8 @@ NoteSequenceEditPage::NoteSequenceEditPage(PageManager &manager, PageContext &co
 
 void NoteSequenceEditPage::enter() {
     updateMonitorStep();
+
+    _inMemorySequence = _project.selectedNoteSequence();
 
     _showDetail = false;
 }
@@ -351,6 +355,13 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+    if (key.pageModifier() && key.is(Key::Step6)) {
+        // undo function
+        _project.setSelectedNoteSequence(_inMemorySequence);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -362,6 +373,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
         int stepIndex = stepOffset() + key.step();
         switch (layer()) {
         case Layer::Gate:
+            _inMemorySequence = _project.selectedNoteSequence();
             sequence.step(stepIndex).toggleGate();
             event.consume();
             break;
@@ -375,6 +387,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
     if (!key.shiftModifier() && key.isStep() && keyPressEvent.count() == 2) {
         int stepIndex = stepOffset() + key.step();
         if (layer() != Layer::Gate) {
+            _inMemorySequence = _project.selectedNoteSequence();
             sequence.step(stepIndex).toggleGate();
             event.consume();
         }
@@ -382,6 +395,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
 
     if (key.isFunction()) {
         if(key.shiftModifier() && key.function() == 2 && _stepSelection.any()) {
+            _inMemorySequence = _project.selectedNoteSequence();
             tieNotes();
             event.consume();
             return;
@@ -392,7 +406,7 @@ void NoteSequenceEditPage::keyPress(KeyPressEvent &event) {
 
     if (key.isEncoder()) {
         track.setPatternFollowDisplay(false);
-
+        _inMemorySequence = _project.selectedNoteSequence();
         if (!_showDetail && _stepSelection.any() && allSelectedStepsActive()) {
             setSelectedStepsGate(false);
         } else {

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
@@ -74,4 +74,6 @@ private:
     StepSelection<CONFIG_STEP_COUNT> _stepSelection;
 
     Container<NoteSequenceBuilder> _builderContainer;
+
+    NoteSequence _inMemorySequence;
 };

--- a/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
+++ b/src/apps/sequencer/ui/pages/NoteSequenceEditPage.h
@@ -39,7 +39,7 @@ private:
     void updateMonitorStep();
     void drawDetail(Canvas &canvas, const NoteSequence::Step &step);
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/NoteSequencePage.cpp
+++ b/src/apps/sequencer/ui/pages/NoteSequencePage.cpp
@@ -60,6 +60,13 @@ void NoteSequencePage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -75,12 +82,13 @@ void NoteSequencePage::keyPress(KeyPressEvent &event) {
     }
 }
 
-void NoteSequencePage::contextShow() {
+void NoteSequencePage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/NoteSequencePage.h
+++ b/src/apps/sequencer/ui/pages/NoteSequencePage.h
@@ -17,7 +17,7 @@ public:
     virtual void keyPress(KeyPressEvent &event) override;
 
 private:
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/PatternPage.cpp
+++ b/src/apps/sequencer/ui/pages/PatternPage.cpp
@@ -232,6 +232,13 @@ void PatternPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -337,12 +344,13 @@ void PatternPage::encoder(EncoderEvent &event) {
     _project.editSelectedPatternIndex(event.value(), event.pressed());
 }
 
-void PatternPage::contextShow() {
+void PatternPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/PatternPage.h
+++ b/src/apps/sequencer/ui/pages/PatternPage.h
@@ -26,7 +26,7 @@ public:
      int *getPressedKeySteps(Key key);
 
 private:
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/ProjectPage.cpp
+++ b/src/apps/sequencer/ui/pages/ProjectPage.cpp
@@ -57,6 +57,12 @@ void ProjectPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         // easter egg
         if (key.is(Key::Step15)) {
@@ -89,12 +95,13 @@ void ProjectPage::encoder(EncoderEvent &event) {
     ListPage::encoder(event);
 }
 
-void ProjectPage::contextShow() {
+void ProjectPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/ProjectPage.h
+++ b/src/apps/sequencer/ui/pages/ProjectPage.h
@@ -18,7 +18,7 @@ public:
     virtual void encoder(EncoderEvent &event) override;
 
 private:
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/SongPage.cpp
+++ b/src/apps/sequencer/ui/pages/SongPage.cpp
@@ -224,6 +224,12 @@ void SongPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -377,12 +383,13 @@ uint8_t SongPage::pressedTrackKeys() const {
     return tracks;
 }
 
-void SongPage::contextShow() {
+void SongPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/SongPage.h
+++ b/src/apps/sequencer/ui/pages/SongPage.h
@@ -29,7 +29,7 @@ private:
 
     uint8_t pressedTrackKeys() const;
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/SystemPage.cpp
+++ b/src/apps/sequencer/ui/pages/SystemPage.cpp
@@ -167,6 +167,13 @@ void SystemPage::keyPress(KeyPressEvent &event) {
         }
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.isFunction()) {
         if (_mode == Mode::Calibration && edit()) {
             if (CalibrationEditFunction(key.function()) == CalibrationEditFunction::Auto) {
@@ -277,12 +284,13 @@ void SystemPage::executeUtilityItem(UtilitiesListModel::Item item) {
     }
 }
 
-void SystemPage::contextShow() {
+void SystemPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/SystemPage.cpp
+++ b/src/apps/sequencer/ui/pages/SystemPage.cpp
@@ -42,7 +42,8 @@ static const ContextMenuModel::Item contextMenuItems[] = {
 SystemPage::SystemPage(PageManager &manager, PageContext &context) :
     ListPage(manager, context, _cvOutputListModel),
     _settings(context.model.settings()),
-    _settingsListModel(_settings.userSettings())
+    _settingsListModel(_settings.userSettings()),
+    _lpSettingsListModel(_settings.launchpadSettings())
 {
     setOutputIndex(0);
 }
@@ -243,7 +244,11 @@ void SystemPage::setMode(Mode mode) {
         setListModel(_utilitiesListModel);
         break;
     case Mode::Settings:
-        setListModel(_settingsListModel);
+        if (_engine.isLaunchpadConnected()) {
+            setListModel(_lpSettingsListModel);
+        } else {
+            setListModel(_settingsListModel);
+        }
         break;
     default:
         break;

--- a/src/apps/sequencer/ui/pages/SystemPage.h
+++ b/src/apps/sequencer/ui/pages/SystemPage.h
@@ -37,7 +37,7 @@ private:
 
     void executeUtilityItem(UtilitiesListModel::Item item);
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/SystemPage.h
+++ b/src/apps/sequencer/ui/pages/SystemPage.h
@@ -59,5 +59,7 @@ private:
     UtilitiesListModel _utilitiesListModel;
     SettingsListModel _settingsListModel;
 
+    LpSettingsListModel _lpSettingsListModel;
+
     uint32_t _encoderDownTicks;
 };

--- a/src/apps/sequencer/ui/pages/TrackPage.cpp
+++ b/src/apps/sequencer/ui/pages/TrackPage.cpp
@@ -55,6 +55,13 @@ void TrackPage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.pageModifier()) {
         return;
     }
@@ -127,12 +134,13 @@ void TrackPage::setTrack(Track &track) {
     }
 }
 
-void TrackPage::contextShow() {
+void TrackPage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/TrackPage.h
+++ b/src/apps/sequencer/ui/pages/TrackPage.h
@@ -21,7 +21,7 @@ public:
 private:
     void setTrack(Track &track);
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/pages/UserScalePage.cpp
+++ b/src/apps/sequencer/ui/pages/UserScalePage.cpp
@@ -55,6 +55,13 @@ void UserScalePage::keyPress(KeyPressEvent &event) {
         return;
     }
 
+
+    if (key.pageModifier() && event.count() == 2) {
+        contextShow(true);
+        event.consume();
+        return;
+    }
+
     if (key.isFunction()) {
         if (key.function() < CONFIG_USER_SCALE_COUNT) {
             setSelectedIndex(key.function());
@@ -84,12 +91,13 @@ void UserScalePage::setSelectedIndex(int index) {
     setEdit(false);
 }
 
-void UserScalePage::contextShow() {
+void UserScalePage::contextShow(bool doubleClick) {
     showContextMenu(ContextMenu(
         contextMenuItems,
         int(ContextAction::Last),
         [&] (int index) { contextAction(index); },
-        [&] (int index) { return contextActionEnabled(index); }
+        [&] (int index) { return contextActionEnabled(index); },
+        doubleClick
     ));
 }
 

--- a/src/apps/sequencer/ui/pages/UserScalePage.h
+++ b/src/apps/sequencer/ui/pages/UserScalePage.h
@@ -20,7 +20,7 @@ public:
 private:
     void setSelectedIndex(int index);
 
-    void contextShow();
+    void contextShow(bool doubleClick = false);
     void contextAction(int index);
     bool contextActionEnabled(int index) const;
 

--- a/src/apps/sequencer/ui/painters/SequencePainter.cpp
+++ b/src/apps/sequencer/ui/painters/SequencePainter.cpp
@@ -99,6 +99,17 @@ void SequencePainter::drawSlide(Canvas &canvas, int x, int y, int w, int h, bool
     }
 }
 
+void SequencePainter::drawBypassScale(Canvas &canvas, int x, int y, int w, int h, bool active) {
+    canvas.setBlendMode(BlendMode::Set);
+    canvas.setColor(Color::Bright);
+
+    if (active) {
+        canvas.drawText(x,y+4, "1");
+    } else {
+        canvas.drawText(x,y+4, "0");
+    }
+}
+
 const std::bitset<4> mask = 0x1;
 void SequencePainter::drawStageRepeatMode(Canvas &canvas, int x, int y, int w, int h, NoteSequence::StageRepeatMode mode) {
     canvas.setBlendMode(BlendMode::Set);

--- a/src/apps/sequencer/ui/painters/SequencePainter.h
+++ b/src/apps/sequencer/ui/painters/SequencePainter.h
@@ -14,6 +14,8 @@ public:
     static void drawLength(Canvas &canvas, int x, int y, int w, int h, int length, int maxLength);
     static void drawLengthRange(Canvas &canvas, int x, int y, int w, int h, int length, int range, int maxLength);
     static void drawSlide(Canvas &canvas, int x, int y, int w, int h, bool active);
+    static void drawBypassScale(Canvas &canvas, int x, int y, int w, int h, bool active);
+
     static void drawStageRepeatMode(Canvas &canvas, int x, int y, int w, int h, NoteSequence::StageRepeatMode mode);
 
     static void drawSequenceProgress(Canvas &canvas, int x, int y, int w, int h, float progress);


### PR DESCRIPTION
- Moving steps in a sequence
- INIT by step selected
- smart cycling on patter follow modes (check if launchpad is connected)
- Show launchpad settings only when a launchpad is connected
- Apply random for selected steps only
- double click page to enter context menu for 2 seconds
- Prevent very short output clock pulses at higher BPMs
- Undo function (alt+s7)
- Curve mode backward run modes play reverse playback
- Bypass the Voltage Table in specific steps of the sequence